### PR TITLE
Fix Incorrect Link for Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 ## Project Pipeline
 
 - [Hosted API](https://productsapi-staging.herokuapp.com/)
-- [API Docs](https://productsapi-staging.herokuapp.com/docs)
+- [API Docs](https://productsapi-staging.herokuapp.com/api/v1/docs)
+- [Postman Documentation](https://documenter.getpostman.com/view/7505181/SVmwxJSm)
 - [Postman Collections](https://www.getpostman.com/collections/f79fa50ac8890d7da743)
 
 


### PR DESCRIPTION
#### What does this PR do?
* Fixes incorrect url for documentation

#### Description of Task to be completed?

#### How should this manually be Tested?
- `git clone` __https://github.com/meetKazuki/products__
- `cd` products
- `git checkout bg-fix-documentation-link`
- `npm install`
- `npm run start:dev`
- Navigate to `localhost:{PORT)/api/v1/docs`

#### What are the relevant Pivotal Tracker stories?

#### Screenshots (if appropriate)